### PR TITLE
Added alternative setup using wstool and a rosinstall file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Metacontrol simulation
 
+## Setup using wstool
+```
+$ mkdir -p ~/metacontrol_ws/src
+$ cd ~/metacontrol_ws
+$ wstool init src https://raw.githubusercontent.com/rosin-project/metacontrol_sim/master/metacontrol_sim.rosinstall
+$ rosdep install --from-path src -y -i -r
+```
+## Manually setup
 
 ### Install Dependencies
 ```
@@ -9,7 +17,6 @@ $ apt-get install ros-melodic-hector-xacro-tools
 $ apt-get install ros-melodic-ridgeback-control
 ```
 ### Create workspace
-
 ```
 $ mkdir -p ~/metacontrol_ws/src
 $ cd ~/metacontrol_ws/src
@@ -24,7 +31,6 @@ git clone https://github.com/rosin-project/brass_gazebo_battery.git
 
 git clone https://github.com/marioney/yumi.git
 
-
 #### Clone Metacontrol simulation
 
 git clone https://github.com/marioney/metacontrol_sim.git
@@ -34,14 +40,14 @@ git clone https://github.com/marioney/metacontrol_sim.git
 git clone https://github.com/marioney/metacontrol_nav.git
 
 
-### Compile
+## Compile
 
 ```
 $ cd ~/metacontrol_ws/src
 $ catkin_make
 $ source devel/setup.bash
 ```
-### Launch simulation and navigation
+## Launch simulation and navigation
 
 ```
 $ roslaunch metacontrol_sim ridgeback_yumi_world.launch

--- a/metacontrol_sim.rosinstall
+++ b/metacontrol_sim.rosinstall
@@ -1,0 +1,12 @@
+- git:
+    local-name: metacontrol_sim
+    uri: https://github.com/rosin-project/metacontrol_sim
+- git:
+    local-name: yumi
+    uri: https://github.com/marioney/yumi
+- git:
+    local-name: metacontrol_nav
+    uri: https://github.com/rosin-project/metacontrol_nav
+- git:
+    local-name: brass_gazebo_battery
+    uri: https://github.com/rosin-project/brass_gazebo_battery.git


### PR DESCRIPTION
I have added a rosinstall file with the non-released repos and add some instructions to install the dependencies automatically, this ensures that we all installed the same set of ROS packages.

:exclamation::exclamation::exclamation::exclamation:
I added a "-r" argument to the rosdep command (i.e. *Continue installing despite errors*) because of some abb libraries that can't be found ** . that means the rosdep command will show the following errors:
```
yumi_hw: Cannot locate rosdep definition for [abb_rws_interface]
yumi_cameras: Cannot locate rosdep definition for [abb_rws_interface]
```
Both errors can be ignored because for the CMakeLists the abb_rws_interface package is marked as additional library and the compile command will not fail.

** for further information: https://answers.ros.org/question/265655/unable-build-abb-yumi-support/
:exclamation::exclamation::exclamation::exclamation: