### PR TITLE
added the ros_graph_parser node and updated rosinstall file

### DIFF
--- a/launch/includes/rosgraph_nodes.launch.xml
+++ b/launch/includes/rosgraph_nodes.launch.xml
@@ -9,5 +9,8 @@
   <node name="rosgraph_monitor_node" pkg="rosgraph_monitor" type="monitor" output="screen">
   </node>
 
+  <node name="ros_graph_parser_node" pkg="ros_graph_parser" type="ros_node" output="screen">
+  </node>
+
 
 </launch>

--- a/metacontrol_sim.rosinstall
+++ b/metacontrol_sim.rosinstall
@@ -1,6 +1,7 @@
 - git:
     local-name: metacontrol_sim
     uri: https://github.com/rosin-project/metacontrol_sim
+    version: MVP_world
 - git:
     local-name: yumi
     uri: https://github.com/marioney/yumi
@@ -13,3 +14,11 @@
 - git:
     local-name: metacontrol_msgs
     uri: https://github.com/rosin-project/metacontrol_msgs
+- git:
+    local-name: rosgraph_monitor
+    uri: https://github.com/rosin-project/rosgraph_monitor
+    version: observers
+- git:
+    local-name: ros_graph_parser
+    uri: https://github.com/ipa-nhg/ros_graph_parser
+    version: SoSymPaper


### PR DESCRIPTION
I added to the launch file the include for the `ros_graph_parser` node, the rosgraph_monitor can't work without it.

I updated also the rosinstall file to get the correct repositories and versions