### PR TITLE
Missing dependency in .rosinstall

### DIFF
--- a/metacontrol_sim.rosinstall
+++ b/metacontrol_sim.rosinstall
@@ -32,3 +32,6 @@
     local-name: mc_mdl_tomasys
     uri: https://github.com/tud-cor/mc_mdl_tomasys.git
     version: v0.1
+- git:
+    local-name: mc_rosgraph_manipulator
+    uri: https://github.com/tud-cor/mc_rosgraph_manipulator.git


### PR DESCRIPTION
Added `mc_rosgraph_manipulator` as dependency in rosinstall